### PR TITLE
Revert "Use the unCDN'd image service as a hack"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Slightly enhanced Express.
 
 Comes with:-
 - [Handlebars](http://handlebarsjs.com/) (with added support for loading partials from `bower_components`)
-- [Origami Image Service](https://imageservice.glb.ft.com/) integration
+- [Origami Image Service](http://image.webservices.ft.com/) integration
 - [Sensible error handling](https://github.com/Financial-Times/express-errors-handler) (configurable via environment variables)
 - Full [Next Flags](https://github.com/Financial-Times/next-feature-flags-client) integration
 - Anti-search engine `GET /robots.txt` (possibly might need to change in the future)

--- a/src/handlebars/resize.js
+++ b/src/handlebars/resize.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = function(width, options) {
-	return '//imageservice.glb.ft.com/v1/images/raw/' + encodeURIComponent(options.fn(this)) + '?width=' + width + '&source=docs&fit=scale-down';
+	return '//image.webservices.ft.com/v1/images/raw/' + encodeURIComponent(options.fn(this)) + '?width=' + width + '&source=docs&fit=scale-down';
 };

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -42,7 +42,7 @@ describe('simple app', function() {
 		it('should do integrate with the image service', function(done) {
 			request(app)
 				.get('/templated')
-				.expect(200, /\/\/imageservice\.glb\.ft\.com\/v1\/images\/raw\//, done);
+				.expect(200, /\/\/image.webservices.ft.com\/v1\/images\/raw\//, done);
 		});
 
 		it('should support loading partials via bower', function(done) {
@@ -139,7 +139,7 @@ describe('simple app', function() {
 			it('should provide an image resizing helper', function(done) {
 				request(app)
 					.get('/templated')
-					.expect(200, /\/\/imageservice\.glb\.ft\.com\/v1\/images\/raw\/http%3A%2F%2Fimage\.jpg\?width=200&source=docs&fit=scale-down/, done);
+					.expect(200, /\/\/image\.webservices.ft.com\/v1\/images\/raw\/http%3A%2F%2Fimage\.jpg\?width=200&source=docs&fit=scale-down/, done);
 			});
 
 		});


### PR DESCRIPTION
/cc @matthew-andrews @richard-still-ft Reverting this for now as the glb image service doesn't seem to like the FT article images.

This reverts commit 70519663ec5a4bcf763188313844142f95e32fcb.