### PR TITLE
Don't instrument internal routes, e.g. __gtg, __help

### DIFF
--- a/main.js
+++ b/main.js
@@ -95,7 +95,7 @@ module.exports = function(options) {
 	// please make this the default (not opt-in)
 	if (options.metrics) {
 		metrics.init({ app: name, flushEvery: 40000 });
-		app.use(function(req, res, next) {
+		app.use(/\/(?!__).*/, function(req, res, next) {
 			metrics.instrument(req, { as: 'express.http.req' });
 			metrics.instrument(res, { as: 'express.http.res' });
 			next();

--- a/main.js
+++ b/main.js
@@ -95,6 +95,8 @@ module.exports = function(options) {
 	// please make this the default (not opt-in)
 	if (options.metrics) {
 		metrics.init({ app: name, flushEvery: 40000 });
+
+		// Matches any reader facing routes, i.e. not those starting with ‘__’
 		app.use(/\/(?!__).*/, function(req, res, next) {
 			metrics.instrument(req, { as: 'express.http.req' });
 			metrics.instrument(res, { as: 'express.http.res' });


### PR DESCRIPTION
cc @commuterjoy 

why write readable, intuitive code when you could write a single line of regex?