### PR TITLE
Stub `console` object

### DIFF
--- a/layouts/vanilla.html
+++ b/layouts/vanilla.html
@@ -7,6 +7,7 @@
 		<meta name="dfp_site" content="test.next.ft" />
 		<link rel="stylesheet" href="{{#hashedAsset}}main.css{{/hashedAsset}}"/>
 		<title>{{#title}}{{{this}}} &mdash; {{/title}}Financial Times</title>
+		{{>stubs}}
 		{{>next-mustard/check}}
 	</head>
 	<body class="o-hoverable-on">

--- a/layouts/wrapper.html
+++ b/layouts/wrapper.html
@@ -7,6 +7,7 @@
 		<meta name="dfp_site" content="test.next.ft" />
 		<link rel="stylesheet" href="{{#hashedAsset}}main.css{{/hashedAsset}}"/>
 		<title>{{#title}}{{{this}}} &mdash; {{/title}}FT.com</title>
+		{{>stubs}}
 		{{>next-mustard/check}}
 	</head>
 	<body class="o-hoverable-on">

--- a/main.js
+++ b/main.js
@@ -65,7 +65,8 @@ module.exports = function(options) {
 
 	var handlebarsPromise = Handlebars(app, {
 		partialsDir: [
-			directory + '/views/partials'
+			directory + '/views/partials',
+			__dirname + '/partials'
 		],
 		defaultLayout: false,
 		layoutsDir: __dirname + '/layouts',

--- a/partials/stubs.html
+++ b/partials/stubs.html
@@ -1,0 +1,10 @@
+<script>
+	// stub console
+	if (!window.console) {
+		window.console = {};
+		var methods = ['info', 'log', 'warn', 'error'];
+		for (var i = 0; i < methods.length; i++) {
+			window.console[methods[i]] = function () {};
+		}
+	}
+</script>

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -151,7 +151,7 @@ describe('simple app', function() {
 		it('wrapper should expose offy flags to client side code', function(done) {
 			request(app)
 				.get('/wrapped')
-				.expect(200, /<html.*data-next-flags="(([a-z\-]+--off))( [a-z\-]+--off)*"/, done);
+				.expect(200, /<html.*data-next-flags="[a-z0-9\-]+--off( [a-z0-9\-]+--off)*"/, done);
 		});
 
 		it('should be possible to inherit a vanilla (inc html head only) layout', function(done) {
@@ -169,7 +169,7 @@ describe('simple app', function() {
 		it('vanilla should expose offy flags to client side code', function(done) {
 			request(app)
 				.get('/wrapped')
-				.expect(200, /<html.*data-next-flags="(([a-z\-]+--off))( [a-z\-]+--off)*"/, done);
+				.expect(200, /<html.*data-next-flags="[a-z0-9\-]+--off( [a-z0-9\-]+--off)*"/, done);
 		});
 		it('should integrate with the image service', function(done) {
 			request(app)


### PR DESCRIPTION
Sometimes ours, sometimes 3rd-party's code contain `console....` calls, which fail in IE<10

So stub it (and needs to be near the beginning of the chain)