### PR TITLE
Add memwatch to log possible memory leaks

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,6 +11,14 @@ var handlebars = require('ft-next-handlebars');
 var barriers = require('next-barrier-component');
 var metrics = require('next-metrics');
 
+// Report suspected memory leaks to Sentry
+if(process.env.NODE_ENV === 'production'){
+	var memwatch = require('memwatch');
+	memwatch.on('leak', function(info){
+		errorsHandler.captureException(new Error('Suspected Memory Leak'), {tags:{info:info}});
+	});
+}
+
 var robots = require('./src/express/robots');
 var normalizeName = require('./src/normalize-name');
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "ft-next-handlebars": "^1.0.1",
     "ft-next-logger": "^1.0.0",
     "isomorphic-fetch": "^2.0.0",
+    "memwatch": "^0.2.2",
     "next-barrier-component": "Financial-Times/next-barrier-component#v1",
     "next-feature-flags-client": "https://github.com/Financial-Times/next-feature-flags-client/archive/v5.1.1.tar.gz",
     "next-metrics": "^1.6.1"


### PR DESCRIPTION
I think this would be a useful thing to have visibility of as we ramp up.

Note, this module is mostly written in C so the compilation step may slow the builds down