### PR TITLE
Serve /__about from root of domain

### DIFF
--- a/main.js
+++ b/main.js
@@ -137,7 +137,7 @@ module.exports = function(options) {
 		}
 	});
 
-	app.get('/' + name + '/__about', function(req, res) {
+	app.get('/__about', function(req, res) {
 		res.set({ 'Cache-Control': 'no-cache' });
 		res.sendFile(directory + '/public/__about.json');
 	});

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -35,7 +35,7 @@ describe('simple app', function() {
 
 	it('should have an about json', function(done) {
 		request(app)
-			.get('/demo-app/__about')
+			.get('/__about')
 			.expect(200, done);
 	});
 


### PR DESCRIPTION
because it's the standard for `GET /__about` and it's not that useful being able to look at it through fastly