### PR TITLE
remove internal capi

### DIFF
--- a/main.js
+++ b/main.js
@@ -49,7 +49,6 @@ var serviceMatchers = {
 	'barriers-api': /^https:\/\/subscribe.ft.com\/memb\/barrier/,
 	'barriers-api-direct': /^https?:\/\/barrier-app\.memb\.ft\.com\/memb\/barrier/,
 	'brightcove': /^http:\/\/api\.brightcove\.com\/services\/library/,
-	'internalcapi': /^http:\/\/contentapi\.ft\.com/,
 	'bertha': /^http:\/\/bertha\.ig\.ft\.com/,
 	'markets': /^http:\/\/markets\.ft\.com/
 };


### PR DESCRIPTION
I'm not sure what the status of rolling out the new url is, so could you do the honours and merge this if/when it's gone from our apps @matthew-andrews 