### PR TITLE
Add Fastly host to service metrics.

### DIFF
--- a/src/service-metrics.js
+++ b/src/service-metrics.js
@@ -49,7 +49,8 @@ var serviceMatchers = {
 	'barriers-api-direct': /^https?:\/\/barrier-app\.memb\.ft\.com\/memb\/barrier/,
 	'brightcove': /^http:\/\/api\.brightcove\.com\/services\/library/,
 	'bertha': /^http:\/\/bertha\.ig\.ft\.com/,
-	'markets': /^http:\/\/markets\.ft\.com/
+	'markets': /^http:\/\/markets\.ft\.com/,
+	'fastly': /^https?:\/\/next\.ft\.com/
 };
 
 module.exports = {


### PR DESCRIPTION
We are calling the Fastly host `next.ft.com` using `fetch` from with our application to perform a `PURGE` request of certain objects. 

This was causing a `Service called but no metrics set up.` warning which we don't want :)