### PR TITLE
This has been replaced by the concordance api

### DIFF
--- a/src/service-metrics.js
+++ b/src/service-metrics.js
@@ -35,9 +35,6 @@ var serviceMatchers = {
 	'capi-v2-content-by-concept': /^https?:\/\/api\.ft\.com\/content\?isAnnotatedBy=http:\/\/api\.ft\.com\/things\/[\w\-]+/,
 	// fastft
 	'fastft': /https?:\/\/clamo\.ftdata\.co\.uk\/api/,
-	// v1 to v2 mapping endpoints
-	'v1-to-v2-mapping-people': /^https:\/\/next-v1tov2-mapping-dev\.herokuapp\.com\/concordance_mapping_v1tov2\/people\/[A-Za-z0-9=\-]+$/,
-	'v1-to-v2-mapping-organisations': /^https:\/\/next-v1tov2-mapping-dev\.herokuapp\.com\/concordance_mapping_v1tov2\/organisations\/[A-Za-z0-9=\-]+$/,
 	// ft.com (temporary for article comment hack)
 	'ft.com': /^https?:\/\/www\.ft\.com\/cms\/s\/[\w\-]+\.html$/,
 	'beacon': /^https?:\/\/next-beacon\.ft\.com\/px\.gif/,


### PR DESCRIPTION
Usage of v1 v2 people endpoint:-

![download 1](https://cloud.githubusercontent.com/assets/825088/8460546/64e93954-201d-11e5-9204-9a6777ee692d.png)

Usage of v1 v2 organisations endpoint:-

![download](https://cloud.githubusercontent.com/assets/825088/8460547/65f77ffe-201d-11e5-8768-0fcc79336147.png)

If it's used anywhere else I want to know about it