### PR TITLE
Add accessibility skip links within wrapper template

### DIFF
--- a/layouts/wrapper.html
+++ b/layouts/wrapper.html
@@ -44,9 +44,9 @@
 
 		{{>n-header-footer/templates/header}}
 
-		{{#if showSkipLinks}}<div id="content">{{#if}}
+		{{#if showSkipLinks}}<div id="content">{{/if}}
 		{{{body}}}
-		{{#if showSkipLinks}}</div>{{#if}}
+		{{#if showSkipLinks}}</div>{{/if}}
 
 		{{#if @root.flags.welcomePanel}}
 			{{>next-welcome/main}}

--- a/layouts/wrapper.html
+++ b/layouts/wrapper.html
@@ -36,7 +36,7 @@
 
 		{{#if showSkipLinks}}
 			<a class="u-visually-hidden" href="#primary-nav">Skip to navigation</a>
-			<a class="u-visually-hidden" href="#content">Skip to content</a>
+			<a class="u-visually-hidden" href="#site-content">Skip to content</a>
 		{{/if}}
 
 		{{#outputBlock 'notification'}}
@@ -44,9 +44,7 @@
 
 		{{>n-header-footer/templates/header}}
 
-		{{#if showSkipLinks}}<div id="content">{{/if}}
 		{{{body}}}
-		{{#if showSkipLinks}}</div>{{/if}}
 
 		{{#if @root.flags.welcomePanel}}
 			{{>next-welcome/main}}

--- a/layouts/wrapper.html
+++ b/layouts/wrapper.html
@@ -33,12 +33,20 @@
 		{{/outputBlock}}
 	</head>
 	<body class="o-hoverable-on">
+
+		{{#if showSkipLinks}}
+			<a class="u-visually-hidden" href="#primary-nav">Skip to navigation</a>
+			<a class="u-visually-hidden" href="#content">Skip to content</a>
+		{{/if}}
+
 		{{#outputBlock 'notification'}}
 		{{/outputBlock}}
 
 		{{>n-header-footer/templates/header}}
 
+		{{#if showSkipLinks}}<div id="content">{{#if}}
 		{{{body}}}
+		{{#if showSkipLinks}}</div>{{#if}}
 
 		{{#if @root.flags.welcomePanel}}
 			{{>next-welcome/main}}

--- a/main.js
+++ b/main.js
@@ -69,7 +69,7 @@ module.exports = function(options) {
 			helpers.flagStatuses = require('./src/handlebars/flag-statuses');
 		}
 		helpers.hashedAsset = require('./src/handlebars/hashed-asset');
-
+		app.locals.showSkipLinks = options.withNavigation;
 		handlebarsPromise = handlebars(app, {
 			partialsDir: [
 				directory + '/views/partials'
@@ -77,8 +77,7 @@ module.exports = function(options) {
 			defaultLayout: false,
 			layoutsDir: options.layoutsDir || __dirname + '/layouts',
 			helpers: helpers,
-			directory: directory,
-			showSkipLinks: options.withNavigation
+			directory: directory
 		});
 	}
 

--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@ module.exports = function(options) {
 	var defaults = {
 		withFlags: true,
 		withHandlebars: true,
-		withNavigation: true,
+		withNavigation: true
 	};
 
 	Object.keys(defaults).forEach(function (prop) {
@@ -77,7 +77,8 @@ module.exports = function(options) {
 			defaultLayout: false,
 			layoutsDir: options.layoutsDir || __dirname + '/layouts',
 			helpers: helpers,
-			directory: directory
+			directory: directory,
+			showSkipLinks: options.withNavigation
 		});
 	}
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -209,6 +209,11 @@ describe('simple app', function() {
 				.expect(200, /<html.*data-next-version="i-am-at-version-x"/, done);
 		});
 
+		it('wrapper should expose accessibility skip links to client side code', function(done){
+			request(app)
+				.get('/wrapped')
+				.expect(200, /<a class="u-visually-hidden" href="#primary-nav">Skip to navigation<\/a>/, done);
+		});
 
 		it('wrapper should expose offy flags to client side code', function(done) {
 			request(app)
@@ -319,6 +324,7 @@ describe('simple app', function() {
 				.get('/with-set-base')
 				.expect(200, /<base target="_parent" href="\/\/next.ft.com">/, done);
 		});
+
 	});
 
 


### PR DESCRIPTION
Adds hidden skip links to the top of the document enabling users using assistive technologies to jump to core sections of the page.

- Only enabled if `withHandlebars` and `withNavigation` are true.
- Requires extended applications to have a `u-visually-hidden` within their CSS
- ~~Extended applications cannot expose their own `#content` html id~~

Closes: #155

##### Potential improvements
- We could go further and follow GitHub's pattern by adding a `tab-index=1"` and visually exposing the element when focused?
- Use `<main>` element for the main content area?

/cc @i-like-robots @tom-parker 