### PR TITLE
make warn 75% to reduce the spam in the sensu web interface

### DIFF
--- a/src/express/sensu.js
+++ b/src/express/sensu.js
@@ -14,7 +14,7 @@ module.exports = function(req, res) {
 			check: util.format('divideSeries(sumSeries(%s),sumSeries(%s))', requests, errors),
 			name: "error-rate",
 			message: "The ratio of errors to good responses is above a healthy rate",
-			warn: 0.05,
+			warn: 0.75,
 			critical: 1,
 			occurences: 3,
 			interval: 60,


### PR DESCRIPTION
This ups the warn limit to 75%. Most users won't notice this as its only really obvious in http://sensu.ft.com 