### PR TITLE
Remove x-powered-by express header

### DIFF
--- a/main.js
+++ b/main.js
@@ -61,6 +61,9 @@ module.exports = function(options) {
 	var sensuChecks = sensu(name, options.sensuChecks);
 	var healthChecks = options.healthChecks;
 
+	//Remove x-powered-by header
+	app.set('x-powered-by', false);
+
 	try {
 		app.locals.__version = require(directory + '/public/__about.json').appVersion;
 	} catch (e) {}


### PR DESCRIPTION
Removes the: `x-powered-by=express` header. This is an unnecessary header causing more bytes over the wire and most importantly opens up to any potential express based security exploitations in the future.

http://expressjs.com/api.html#app.settings.table