### PR TITLE
Add preconnect hints to wrapper template

### DIFF
--- a/layouts/wrapper.html
+++ b/layouts/wrapper.html
@@ -8,6 +8,13 @@
 		{{#if setBase}}
 			<base target="_parent" href="{{setBase}}"/>
 		{{/if}}
+
+		<link rel="preconnect" href="https://next-geebee.ft.com" />
+		<link rel="preconnect" href="https://spoor-api.ft.com" />
+		<link rel="preconnect" href="https://track.ft.com" />
+		<link rel="preconnect" href="https://stats.ft.com" />
+		{{{preconnect}}}
+
 		<link rel="stylesheet" href="{{#hashedAsset}}main.css{{/hashedAsset}}"/>
 
 		<link rel="apple-touch-icon" sizes="180x180" href="https://next-geebee.ft.com/assets/brand-alpha/icons/apple-touch-icon-180x180.png"/>


### PR DESCRIPTION
This adds new `preconnect` hints (part of [resource hints API](http://w3c.github.io/resource-hints/#preconnect)) to give the browser hints to which hosts are critical for our application and we would like create a TCP connections for in advance before the parser finds the resources in the DOM. Ultimately reducing page load time.

To start with I've used the FT hosts which are found of every page. But have also allowed the ability for applications to add their own such as Livefyre for article pages etc.

/cc @richard-still-ft @matthew-andrews @aintgoin2goa 