### PR TITLE
Healthcheck promises

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /node_modules/
 /bower_components/
+.idea/

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ This check object can optionally be wrapped in a promise. The promise should be 
 
 An example health check that returns a promise might look a bit like this:
 
-```
+```js
 function checkIfOk() {
 	return somePromiseFunction()
 		.then((result) => {

--- a/README.md
+++ b/README.md
@@ -147,3 +147,36 @@ This’ll make sure your tests wait for flags to be ready.
 Each health check should take the form of an object with a getStatus function. The getStatus function must return a valid check object (see the [FT Check Standard](https://docs.google.com/document/edit?id=1ftlkDj1SUXvKvKJGvoMoF1GnSUInCNPnNGomqTpJaFk)).
 
 This check object can optionally be wrapped in a promise. The promise should be designed to always resolve. If the check fails, the promise should return the check object with its 'ok' attribute set to false.
+
+An example health check that returns a promise might look a bit like this:
+
+```
+function checkIfOk() {
+	return somePromiseFunction()
+		.then((result) => {
+			return result == 10;
+		})
+		.catch((err) => {
+			return false;
+		});
+}
+
+
+var healthCheck = {
+	getStatus: () => {
+		return checkIfOk()
+			.then((result) => {
+				return {
+					name: "Some healthcheck",
+					ok: result,
+					businessImpact: "None",
+					checkOutput: 'checking...',
+					severity: 1,
+					lastUpdated: new Date(),
+					technicalSummary: "lorem ipsum",
+					panicGuide: "lorem ipsum"
+				};
+			})
+	}
+};
+```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Comes with:-
 - `__version` is set to the same value as that used by [next-build-tools/about](https://github.com/Financial-Times/next-build-tools/blob/master/lib/about.js) (exposed as `data-next-version` on the `<html>` tag in templates)
 - Provides a range of [handlebars helpers](#handlebars-helpers), including template inheritance and layouts
 - instruments `fetch` to send data about server-to-server requests to graphite. See main.js for a list of services already instrumented. To add more services extend the list or, for services specific to a particular app, pass in a 'serviceDependencies' option (see examples below)
+- Provides an solution for returning health checks that adhere to the [FT Health Check Standard](https://docs.google.com/document/d/18hefJjImF5IFp9WvPAm9Iq5_GmWzI9ahlKSzShpQl1s/edit#)
 
 ## Installation
 
@@ -69,6 +70,9 @@ var app = express({
 	withFlags: false, // disable feature flag middleware
 	withHandlebars: false // disable handlebars middleware
 	withBackendAuthentication: false // disable authentication which only allows requests in via fastly
+
+	// Optional, defaults to empty array
+	healthChecks: []
 });
 
 app.get('/', function(req, res, next) {
@@ -136,3 +140,10 @@ before(function() {
 ```
 
 This’ll make sure your tests wait for flags to be ready.
+
+
+## Health checks
+
+Each health check should take the form of an object with a getStatus function. The getStatus function must return a valid check object (see the [FT Check Standard](https://docs.google.com/document/edit?id=1ftlkDj1SUXvKvKJGvoMoF1GnSUInCNPnNGomqTpJaFk)).
+
+This check object can optionally be wrapped in a promise. The promise should be designed to always resolve. If the check fails, the promise should return the check object with its 'ok' attribute set to false.

--- a/test/health.test.js
+++ b/test/health.test.js
@@ -4,24 +4,82 @@
 var request = require('supertest');
 var app = require('./fixtures/app/main');
 
-describe('health', function() {
+var nextExpress = require('../main');
 
-	it('by default it should not 500 /__health.1', function(done) {
+describe('health', function () {
+
+	it('by default it should not 500 /__health.1', function (done) {
 		request(app)
 			.get('/__health.1')
 			.expect(200, done);
 	});
 
-	it('by default it should not 500 /__health.2', function(done) {
+	it('by default it should not 500 /__health.2', function (done) {
 		request(app)
 			.get('/__health.2')
 			.expect(200, done);
 	});
 
-	it('by default it should 500 /__health.3', function(done) {
+	it('by default it should 500 /__health.3', function (done) {
 		request(app)
 			.get('/__health.3')
 			.expect(500, done);
 	});
+
+	it('but if there are passing health checks it should 200 /__health.3', function (done) {
+
+		var app = nextExpress({
+			healthChecks: [
+				{
+					getStatus: function () {
+						return {
+							ok: true
+						}
+					}
+				}
+			]
+		});
+
+		request(app)
+			.get('/__health.3')
+			.expect(200, done);
+	});
+
+	it('should handle health checks returned as promises', function (done) {
+
+		var app = nextExpress({
+			healthChecks: [
+				{
+					getStatus: function () {
+						return Promise.resolve({
+							ok: true
+						})
+					}
+				}
+			]
+		});
+
+		request(app)
+			.get('/__health')
+			.expect(200, done);
+	});
+
+	it('should 500 if a health check returns a failing promise (this is always wrong)', function (done) {
+
+		var app = nextExpress({
+			healthChecks: [
+				{
+					getStatus: function () {
+						return Promise.reject();
+					}
+				}
+			]
+		});
+
+		request(app)
+			.get('/__health')
+			.expect(500, done);
+	});
+
 
 });


### PR DESCRIPTION
@matthew-andrews I've fiddled the health check stuff in next express so it can handle async (like we need for the myft api health check)

Not sure I'm pleased with how I'm handling the case where the health check results in a failing promise (which the docs advise should be avoided). At the minute it just 500s, as I can't think of a reasonable way to make it more precise. Any ideas?