### PR TITLE
Export the express.static class method to use within applicaitons

### DIFF
--- a/main.js
+++ b/main.js
@@ -222,6 +222,7 @@ module.exports = function(options) {
 };
 
 module.exports.Router = express.Router;
+module.exports.static = express.static;
 module.exports.services = serviceMetrics.services;
 module.exports.metrics = metrics;
 module.exports.logger = nextLogger.logger;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ft-next-express",
-  "version": "15.2.0",
+  "version": "15.3.0",
   "main": "main.js",
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
I have the need to use the `express.static` middleware within an application to serve some precompiled documentation. We currently don't expose any of Expresses built in methods such as `static` to the outer application. 

### Usage:
`app.use('/docs', express.static('public/docs'));`