### PR TITLE
Fixes an app that proxies to myFT

### DIFF
--- a/src/handlebars/hashed-asset.js
+++ b/src/handlebars/hashed-asset.js
@@ -18,7 +18,7 @@ module.exports = function(options) {
 		logger.warn("./public/asset-hashes.json not found.  Falling back to un-fingerprinted files.");
 	}
 	if (assetHash) {
-		return '/hashed-assets/' + options.data.root.__name + '/' + assetHash;
+		return 'https://next.ft.com/hashed-assets/' + options.data.root.__name + '/' + assetHash;
 	}
 	return fallback;
 };


### PR DESCRIPTION
We're bringing back an absolute URL in order to fix access to assets via the [next-clippings-proxy](https://github.com/Financial-Times/next-clippings-proxy) app, which proxies to the myFT tour page. (Not using next-geebee while a separate issue is being diagnosed.)