### PR TITLE
csrf protection

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,16 +6,19 @@
     "test": "make test"
   },
   "dependencies": {
+    "@financial-times/n-handlebars": "^1.4.1",
+    "@financial-times/n-navigation": "^5.0.4",
+    "body-parser": "^1.14.1",
+    "cookie-parser": "^1.4.0",
+    "csurf": "^1.8.3",
     "debounce": "^1.0.0",
     "debug": "^2.2.0",
     "express": "^4.10.5",
     "express-errors-handler": "^1.0.0",
     "fetchres": "^1.3.0",
-    "@financial-times/n-handlebars": "^1.4.1",
     "ft-next-logger": "^4.0.0",
-    "@financial-times/n-navigation": "^5.0.4",
-    "next-beacon-node-client": "https://github.com/Financial-Times/next-beacon-node-client/archive/v2.1.3.tar.gz",
     "isomorphic-fetch": "^2.0.0",
+    "next-beacon-node-client": "https://github.com/Financial-Times/next-beacon-node-client/archive/v2.1.3.tar.gz",
     "next-feature-flags-client": "^8.0.0",
     "next-metrics": "^1.16.1"
   },


### PR DESCRIPTION
Security FTW: https://github.com/pillarjs/understanding-csrf

This is necessary for Next as the core experience for myFT requires requests to be made via forms.

Using [csurf](https://www.npmjs.com/package/csurf), this PR puts a value `csrfToken` in `res.locals` (which then appears on the Handlebars root context) that needs to be provided with any form or XHR request that isn't a GET, HEAD or OPTIONS.

This'll be a breaking change for any app that makes a request like this so will have to be a major version bump.