### PR TITLE
Add subscribe and sign-in URLs to the navigation model

### DIFF
--- a/src/navigation/navigationModel.js
+++ b/src/navigation/navigationModel.js
@@ -4,8 +4,10 @@ function NavigationModel(flags, isAnon){
 	this.myFT = {};
 	this.myAccount = isAnon ? null : {};
 	this.signIn = isAnon ? {} : null;
+	this.signInUrl = '/login';
 	this.signOut = !isAnon ? {} : null;
 	this.subscribe = isAnon ? {} : null;
+	this.subscribeUrl = '/products?segID=400863&segmentID=190b4443-dc03-bd53-e79b-b4b6fbd04e64';
 }
 
 module.exports = NavigationModel;

--- a/test/anon/anon.spec.js
+++ b/test/anon/anon.spec.js
@@ -4,7 +4,6 @@ var request = require('supertest');
 var nextExpress = require('../../main');
 var expect = require('chai').expect;
 
-
 describe('Anonymous Middleware', function() {
 	var app;
 	var locals;
@@ -48,30 +47,5 @@ describe('Anonymous Middleware', function() {
 				expect(locals.firstClickFreeModel).to.have.property('subscribeNowLink');
 			})
 			.end(done);
-	});
-
-	describe('Navigation model', function(){
-
-		//todo [PW 9/6/15] this stuff doesn't belong here but not sure where it should go
-
-		it('Should set the myFT property to an object', function(done){
-			request(app)
-				.get('/')
-				.set('FT-User-UUID', 'xvdsvdfvdfs')
-				.expect(function(){
-					expect(locals.navigationModel.myFT).to.be.an('object');
-				})
-				.end(done);
-		});
-
-		it('Should set the myAccount property to an object if user is not anonymous', function(done){
-			request(app)
-				.get('/')
-				.set('FT-User-UUID', 'dkvbdfkjvbh')
-				.expect(function(){
-					expect(locals.navigationModel.myAccount).to.be.an('object');
-				})
-				.end(done);
-		});
 	});
 });

--- a/test/navigation/navigation.spec.js
+++ b/test/navigation/navigation.spec.js
@@ -1,0 +1,38 @@
+'use strict';
+/*global describe, it, beforeEach*/
+var request = require('supertest');
+var nextExpress = require('../../main');
+var expect = require('chai').expect;
+
+describe('Navigation model', function() {
+	var app;
+	var locals;
+
+	beforeEach(function(){
+		app = nextExpress({ withFlags:true, withHandlebars:true });
+		app.get('/', function(req, res){
+			locals = res.locals;
+			res.sendStatus(200).end();
+		});
+	});
+
+	it('Should set the myFT property to an object', function(done){
+		request(app)
+			.get('/')
+			.set('FT-User-UUID', 'xvdsvdfvdfs')
+			.expect(function(){
+				expect(locals.navigationModel.myFT).to.be.an('object');
+			})
+			.end(done);
+	});
+
+	it('Should set the myAccount property to an object if user is not anonymous', function(done){
+		request(app)
+			.get('/')
+			.set('FT-User-UUID', 'dkvbdfkjvbh')
+			.expect(function(){
+				expect(locals.navigationModel.myAccount).to.be.an('object');
+			})
+			.end(done);
+	});
+});

--- a/test/navigation/navigation.spec.js
+++ b/test/navigation/navigation.spec.js
@@ -1,36 +1,36 @@
 'use strict';
-/*global describe, it, beforeEach*/
-var request = require('supertest');
-var nextExpress = require('../../main');
-var expect = require('chai').expect;
 
-describe('Navigation model', function() {
-	var app;
-	var locals;
+const request = require('supertest');
+const nextExpress = require('../../main');
+const expect = require('chai').expect;
 
-	beforeEach(function(){
+describe('Navigation model', () => {
+	let app;
+	let locals;
+
+	beforeEach(() => {
 		app = nextExpress({ withFlags:true, withHandlebars:true });
-		app.get('/', function(req, res){
+		app.get('/', (req, res) => {
 			locals = res.locals;
 			res.sendStatus(200).end();
 		});
 	});
 
-	it('Should set the myFT property to an object', function(done){
+	it('Should set the myFT property to an object', done => {
 		request(app)
 			.get('/')
 			.set('FT-User-UUID', 'xvdsvdfvdfs')
-			.expect(function(){
+			.expect(() => {
 				expect(locals.navigationModel.myFT).to.be.an('object');
 			})
 			.end(done);
 	});
 
-	it('Should set the myAccount property to an object if user is not anonymous', function(done){
+	it('Should set the myAccount property to an object if user is not anonymous', done => {
 		request(app)
 			.get('/')
 			.set('FT-User-UUID', 'dkvbdfkjvbh')
-			.expect(function(){
+			.expect(() => {
 				expect(locals.navigationModel.myAccount).to.be.an('object');
 			})
 			.end(done);

--- a/test/navigation/navigation.spec.js
+++ b/test/navigation/navigation.spec.js
@@ -16,7 +16,7 @@ describe('Navigation model', () => {
 		});
 	});
 
-	it('Should set the myFT property to an object', done => {
+	it('Should set the myFT property to an object if user is not anonymous', done => {
 		request(app)
 			.get('/')
 			.set('FT-User-UUID', 'xvdsvdfvdfs')
@@ -32,6 +32,26 @@ describe('Navigation model', () => {
 			.set('FT-User-UUID', 'dkvbdfkjvbh')
 			.expect(() => {
 				expect(locals.navigationModel.myAccount).to.be.an('object');
+			})
+			.end(done);
+	});
+
+	it('Should set the signInUrl property to a string beginning with `https://` or  `/`', done => {
+		request(app)
+			.get('/')
+			.expect(() => {
+				expect(locals.navigationModel.signInUrl).to.be.a('string');
+				expect(locals.navigationModel.signInUrl).to.match(/^(https:\/)?\//);
+			})
+			.end(done);
+	});
+
+	it('Should set the subscribeUrl property to a string beginning with `https://` or  `/`', done => {
+		request(app)
+			.get('/')
+			.expect(() => {
+				expect(locals.navigationModel.subscribeUrl).to.be.a('string');
+				expect(locals.navigationModel.subscribeUrl).to.match(/^(https:\/)?\//);
 			})
 			.end(done);
 	});


### PR DESCRIPTION
- moves navigation model tests out into their own file
- adds subscribeUrl and signInUrl to avoid duplicating links all over the site